### PR TITLE
added two tricks to improve UX sending and receiving msg

### DIFF
--- a/app/Http/Controllers/ThreadsController.php
+++ b/app/Http/Controllers/ThreadsController.php
@@ -75,7 +75,7 @@ class ThreadsController extends Controller
         /* Emmit Event */
         event(new \App\Events\NewMessage($message, $thread));
 
-        return response()->json($message);
+        return response()->json(['message'=>$message, 'thread'=>$thread]);
     }
 
     public function chatMarkMessagesAsRead ( Request $request )

--- a/resources/assets/js/components/ActiveConversationForm.vue
+++ b/resources/assets/js/components/ActiveConversationForm.vue
@@ -29,13 +29,15 @@
         return false
       },
       sendMessage() {
+        var content = this.content
+        this.content = ""
         var data = {
-          content: this.content,
+          content: content,
           thread_id: this.getCurrentConversation.id
         }
         this.$http.post('/chat/send/message', data).then(
           (response) => {
-            this.content = ""
+            this.$store.dispatch('addMessage', response.body )
             // success callback do nothing as updating message feed is done through socket
           },
           (response) => {

--- a/resources/assets/js/store/store.js
+++ b/resources/assets/js/store/store.js
@@ -41,7 +41,9 @@ const mutations = {
     },
     ADD_MESSAGE_TO_CONVERSATION ( state, data ) {
       var conversation =  state.conversations.find( conversation => conversation.id === data.thread.id)
-      conversation.messages.push(data.message)
+      var message = conversation.messages.find( msg => msg.id == data.message.id )
+      if ( ! message )
+        conversation.messages.push(data.message)
     },
     ADD_CONVERSATION ( state, conversation ) {
       state.conversations.push(conversation);


### PR DESCRIPTION
Added msg on send to store after API response as opposed to adding it after it is emitted from node - slightly better UX.
Clear msg input before sending msg - again slightly smoother UX.