### PR TITLE
added getters for active convo msg and active convo participants

### DIFF
--- a/resources/assets/js/components/ActiveConversationBody.vue
+++ b/resources/assets/js/components/ActiveConversationBody.vue
@@ -2,7 +2,7 @@
 
     <div class="sidebar-body">
         <ul class="messages-list">
-            <li v-for="message in getCurrentConversation.messages"
+            <li v-for="message in messages"
                 :class="{ message: true, reply: isOtherThanCurrentUser(message) }"
             >
                 <div class="message-info">
@@ -47,8 +47,8 @@
       activeConversationId: function() {
         return this.$store.state.conversation_id
       },
-      getCurrentConversation: function() {
-        return this.$store.getters.currentConversation
+      messages: function() {
+        return this.$store.getters.currentConversationMessages
       }
     }
   }

--- a/resources/assets/js/components/ActiveConversationHeading.vue
+++ b/resources/assets/js/components/ActiveConversationHeading.vue
@@ -53,14 +53,26 @@
 
 
       participants: function() {
-          var participantsEmails = []
-          var participantsWithoutCurrentUser = this.$store.getters.currentConversation.participants.filter(function(participant){
+/*          var participantsWithoutCurrentUser = this.$store.getters.currentConversation.participants.filter(function(participant){
             return participant.email != this.$store.state.currentUser.email
             }.bind(this))
           $.each(participantsWithoutCurrentUser, function(index, participant){
             participantsEmails.push(participant.email)
             })
             return participantsEmails
+*/
+          var participantsEmails = []
+          var currentUserEmail = this.$store.state.currentUser.email
+          var participants = this.$store.getters.currentConversationParticipants
+          if ( participants.length == 0 )
+            return participantsEmails
+          var participantsWithoutCurrentUser = participants.filter(function(participant){
+            return participant.email != currentUserEmail
+          })
+          $.each(participantsWithoutCurrentUser, function(index, participant){
+            participantsEmails.push(participant.email)
+          })
+          return participantsEmails
       }
     }
   }

--- a/resources/assets/js/store/store.js
+++ b/resources/assets/js/store/store.js
@@ -112,8 +112,19 @@ const getters = {
   currentConversation: state => {
     return state.conversations.find( conversation => conversation.id === state.conversation_id)
   },
+  currentConversationMessages: state => {
+    var cc = state.conversations.find( conversation => conversation.id === state.conversation_id)
+    if ( cc )
+      return cc.messages
+
+    return []
+  },
   currentConversationParticipants: state => {
-    return state.conversations.find( conversation => conversation.id === state.conversation_id).participants
+    var cc = state.conversations.find( conversation => conversation.id === state.conversation_id)
+    if ( cc )
+      return cc.participants
+
+    return []
   },
   conversations: state => {
     return state.conversations


### PR DESCRIPTION
Fixing bug appearing on server - cannot read participants of undefined & cannot read messages of undefined.
As the name said component is trying to access an array of objects resulting from find() which returns null if object is not found. Since that object is not found at that time it throws an error. To fix this I've added specific getters that return empty array or array of object so when rendering msgs or participants through for loop it doesn't fail.